### PR TITLE
Remove gradle wrapper-validation action and update setup-gradle to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v3
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
         run: ./gradlew build
         env:


### PR DESCRIPTION
For unknown reasons, the `wrapper-validation@v3` action [fails](https://github.com/Antimonit/strikt/actions/runs/15795988119/job/44528047364?pr=1) with:

```
Run gradle/actions/wrapper-validation@v3
  with:
    min-wrapper-count: 1
    allow-snapshots: false
Error: Multiple errors returned
Error: Error 0: connect ETIMEDOUT 104.16.73.101:443
Error: connect ETIMEDOUT 104.16.73.101:443
    at createConnectionError (node:net:1652:14)
    at Timeout.internalConnectMultipleTimeout (node:net:1711:38)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 1: connect ENETUNREACH 2606:4700::6810:4965:443 - Local (:::0)
Error: connect ENETUNREACH 2606:4700::6810:4965:443 - Local (:::0)
    at internalConnectMultiple (node:net:1186:16)
    at Timeout.internalConnectMultipleTimeout (node:net:1716:5)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 2: connect ETIMEDOUT 104.16.72.101:443
Error: connect ETIMEDOUT 104.16.72.101:443
    at createConnectionError (node:net:1652:14)
    at Timeout.internalConnectMultipleTimeout (node:net:1711:38)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 3: connect ENETUNREACH 2606:4700::6810:4865:443 - Local (:::0)
Error: connect ENETUNREACH 2606:4700::6810:4865:443 - Local (:::0)
    at internalConnectMultiple (node:net:1186:16)
    at Timeout.internalConnectMultipleTimeout (node:net:1716:5)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
```

There is a newer version of the [`wrapper-validation@v4`](https://community.gradle.org/github-actions/docs/wrapper-validation/#usage) action.

There is, however, also a new version of the `setup-gradle@v4` action, which newly performs the validation as well.

See https://community.gradle.org/github-actions/docs/setup-gradle/#gradle-wrapper-validation

Hopefully this resolves the timeouts.