### PR TITLE
Do not fail project sync if ossrhToken and ossrhTokenPassword properties do not exist 

### DIFF
--- a/buildSrc/src/main/kotlin/published.gradle.kts
+++ b/buildSrc/src/main/kotlin/published.gradle.kts
@@ -13,8 +13,8 @@ publishing {
       name = "nexus"
       url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
       credentials {
-        username = findProperty("ossrhToken") as String
-        password = findProperty("ossrhTokenPassword") as String
+        username = findProperty("ossrhToken") as String?
+        password = findProperty("ossrhTokenPassword") as String?
       }
     }
   }


### PR DESCRIPTION
Trying to sync the project as is throws:

```
null cannot be cast to non-null type kotlin.String
null cannot be cast to non-null type kotlin.String

Gradle's dependency cache may be corrupt (this sometimes occurs after a network connection timeout.)

Re-download dependencies and sync project (requires network)
The state of a Gradle build process (daemon) may be corrupt. Stopping all Gradle daemons may solve this problem.

Stop Gradle build processes (requires restart)
Your project may be using a third-party plugin which is not compatible with the other plugins in the project or the version of Gradle requested by the project.

In the case of corrupt Gradle processes, you can also try closing the IDE and then killing all Java processes.
```