### PR TITLE
Replace line separator

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -172,7 +172,7 @@ internal open class DefaultResultWriter : ResultWriter {
     node: AssertionNode<*>
   ) {
     if (node is DescribedNode) {
-      writer.append(EOL)
+      writer.appendLine()
     }
   }
 
@@ -193,5 +193,3 @@ internal open class DefaultResultWriter : ResultWriter {
     writer.append("▼ ")
   }
 }
-
-private val EOL = System.lineSeparator()

--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -194,4 +194,4 @@ internal open class DefaultResultWriter : ResultWriter {
   }
 }
 
-private val EOL = System.getProperty("line.separator")
+private val EOL = System.lineSeparator()


### PR DESCRIPTION
See https://github.com/robfletcher/strikt/pull/307

---

TL;DR: On a Windows machine, many tests fail due to incorrect line endings. The library assumes Java internally uses `\r\n` on Windows, but `\r\n` should be only used for user-facing output. The internal Java representation still uses `\n`, even when running on Windows.