### PR TITLE
Fix the :site subproject Orchid dependency

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,8 +25,7 @@ dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
     mavenCentral()
-    @Suppress("DEPRECATION")
-    jcenter {
+    maven("https://www.jitpack.io") {
       content { includeGroup("io.github.javaeden.orchid") }
     }
   }


### PR DESCRIPTION
The Orchid library is no longer available on `jcenter` (since it is completely shut down) but still exists on jitpack.