### PR TITLE
Convention plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,5 @@
-import com.adarshr.gradle.testlogger.TestLoggerExtension
-import com.adarshr.gradle.testlogger.theme.ThemeType.MOCHA_PARALLEL
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import io.codearte.gradle.nexus.NexusStagingExtension
-import org.gradle.api.JavaVersion.VERSION_17
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jmailen.gradle.kotlinter.KotlinterExtension
 import kotlin.text.RegexOption.IGNORE_CASE
 
 plugins {
@@ -29,57 +22,6 @@ allprojects {
         useVersion(libs.versions.kotlin.get())
       }
     }
-  }
-}
-
-subprojects {
-  afterEvaluate {
-    plugins.withId("kotlin") {
-      configure<JavaPluginExtension> {
-        sourceCompatibility = VERSION_17
-      }
-
-      tasks.withType<KotlinCompile> {
-        compilerOptions {
-          jvmTarget.set(JVM_17)
-          languageVersion.set(KOTLIN_2_0)
-          javaParameters = true
-          freeCompilerArgs = listOf("-Xjvm-default=all")
-          allWarningsAsErrors = true
-        }
-      }
-
-      dependencies {
-        "implementation"(platform(libs.kotlin.bom))
-        "implementation"(platform(libs.kotlinx.coroutines.bom))
-
-        "testImplementation"(platform(libs.junit.bom))
-        "testImplementation"(libs.junit.jupiter.api)
-        "testRuntimeOnly"(libs.junit.jupiter.engine)
-      }
-
-      // Test with JUnit 5
-      tasks.withType<Test> {
-        systemProperty("junit.jupiter.execution.parallel.enabled", "false")
-        useJUnitPlatform {
-          includeEngines("junit-jupiter", "failgood")
-        }
-      }
-
-      // Lint Kotlin code
-      apply(plugin = "org.jmailen.kotlinter")
-      configure<KotlinterExtension> {
-        ignoreFailures = true
-//        indentSize = 2
-        reporters = arrayOf("html", "plain")
-      }
-    }
-  }
-
-  apply(plugin = "com.adarshr.test-logger")
-  configure<TestLoggerExtension> {
-    theme = MOCHA_PARALLEL
-    showSimpleNames = true
   }
 }
 

--- a/buildLogic/build.gradle.kts
+++ b/buildLogic/build.gradle.kts
@@ -6,5 +6,8 @@ plugins {
 
 dependencies {
   implementation(libs.plugin.dokka)
+  implementation(libs.plugin.kotlin)
+  implementation(libs.plugin.kotlinter)
   implementation(libs.plugin.nebula.publishing)
+  implementation(libs.plugin.test.logger)
 }

--- a/buildLogic/src/main/kotlin/strikt/gradle/kotlin-jvm.gradle.kts
+++ b/buildLogic/src/main/kotlin/strikt/gradle/kotlin-jvm.gradle.kts
@@ -1,6 +1,5 @@
 package strikt.gradle
 
-import com.adarshr.gradle.testlogger.theme.ThemeType
 import org.gradle.api.JavaVersion
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.testing.Test
@@ -11,8 +10,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
   id("org.jetbrains.kotlin.jvm")
-  id("org.jmailen.kotlinter")
-  id("com.adarshr.test-logger")
+  id("strikt.gradle.kotlinter")
+  id("strikt.gradle.test-logger")
 }
 
 configure<JavaPluginExtension> {
@@ -46,16 +45,4 @@ tasks.withType<Test> {
   useJUnitPlatform {
     includeEngines("junit-jupiter", "failgood")
   }
-}
-
-// Lint Kotlin code
-kotlinter {
-  ignoreFailures = true
-//  indentSize = 2
-  reporters = arrayOf("html", "plain")
-}
-
-testlogger {
-  theme = ThemeType.MOCHA_PARALLEL
-  showSimpleNames = true
 }

--- a/buildLogic/src/main/kotlin/strikt/gradle/kotlin-jvm.gradle.kts
+++ b/buildLogic/src/main/kotlin/strikt/gradle/kotlin-jvm.gradle.kts
@@ -1,0 +1,64 @@
+package strikt.gradle
+
+import com.adarshr.gradle.testlogger.TestLoggerExtension
+import com.adarshr.gradle.testlogger.theme.ThemeType
+import org.gradle.api.JavaVersion
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jmailen.gradle.kotlinter.KotlinterExtension
+
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
+
+configure<JavaPluginExtension> {
+  sourceCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<KotlinCompile> {
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_17)
+    languageVersion.set(KotlinVersion.KOTLIN_2_0)
+    javaParameters = true
+    freeCompilerArgs = listOf("-Xjvm-default=all")
+    allWarningsAsErrors = true
+  }
+}
+
+val libs = the<VersionCatalogsExtension>().named("libs")
+
+dependencies {
+  "implementation"(platform(libs.findLibrary("kotlin-bom").get()))
+  "implementation"(platform(libs.findLibrary("kotlinx-coroutines-bom").get()))
+
+  "testImplementation"(platform(libs.findLibrary("junit-bom").get()))
+  "testImplementation"(libs.findLibrary("junit-jupiter-api").get())
+  "testRuntimeOnly"(libs.findLibrary("junit-jupiter-engine").get())
+}
+
+// Test with JUnit 5
+tasks.withType<Test> {
+  systemProperty("junit.jupiter.execution.parallel.enabled", "false")
+  useJUnitPlatform {
+    includeEngines("junit-jupiter", "failgood")
+  }
+}
+
+// Lint Kotlin code
+apply(plugin = "org.jmailen.kotlinter")
+configure<KotlinterExtension> {
+  ignoreFailures = true
+//  indentSize = 2
+  reporters = arrayOf("html", "plain")
+}
+
+apply(plugin = "com.adarshr.test-logger")
+configure<TestLoggerExtension> {
+  theme = ThemeType.MOCHA_PARALLEL
+  showSimpleNames = true
+}

--- a/buildLogic/src/main/kotlin/strikt/gradle/kotlin-jvm.gradle.kts
+++ b/buildLogic/src/main/kotlin/strikt/gradle/kotlin-jvm.gradle.kts
@@ -1,6 +1,5 @@
 package strikt.gradle
 
-import com.adarshr.gradle.testlogger.TestLoggerExtension
 import com.adarshr.gradle.testlogger.theme.ThemeType
 import org.gradle.api.JavaVersion
 import org.gradle.api.plugins.JavaPluginExtension
@@ -9,18 +8,18 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jmailen.gradle.kotlinter.KotlinterExtension
 
 plugins {
   id("org.jetbrains.kotlin.jvm")
+  id("org.jmailen.kotlinter")
+  id("com.adarshr.test-logger")
 }
 
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
 }
 
-tasks.withType<KotlinCompile> {
+kotlin {
   compilerOptions {
     jvmTarget.set(JvmTarget.JVM_17)
     languageVersion.set(KotlinVersion.KOTLIN_2_0)
@@ -50,15 +49,13 @@ tasks.withType<Test> {
 }
 
 // Lint Kotlin code
-apply(plugin = "org.jmailen.kotlinter")
-configure<KotlinterExtension> {
+kotlinter {
   ignoreFailures = true
 //  indentSize = 2
   reporters = arrayOf("html", "plain")
 }
 
-apply(plugin = "com.adarshr.test-logger")
-configure<TestLoggerExtension> {
+testlogger {
   theme = ThemeType.MOCHA_PARALLEL
   showSimpleNames = true
 }

--- a/buildLogic/src/main/kotlin/strikt/gradle/kotlin-jvm.gradle.kts
+++ b/buildLogic/src/main/kotlin/strikt/gradle/kotlin-jvm.gradle.kts
@@ -1,9 +1,7 @@
 package strikt.gradle
 
 import org.gradle.api.JavaVersion
-import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.testing.Test
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -14,7 +12,7 @@ plugins {
   id("strikt.gradle.test-logger")
 }
 
-configure<JavaPluginExtension> {
+java {
   sourceCompatibility = JavaVersion.VERSION_17
 }
 

--- a/buildLogic/src/main/kotlin/strikt/gradle/kotlinter.gradle.kts
+++ b/buildLogic/src/main/kotlin/strikt/gradle/kotlinter.gradle.kts
@@ -1,0 +1,12 @@
+package strikt.gradle
+
+plugins {
+  id("org.jmailen.kotlinter")
+}
+
+// Lint Kotlin code
+kotlinter {
+  ignoreFailures = true
+  // indentSize = 2
+  reporters = arrayOf("html", "plain")
+}

--- a/buildLogic/src/main/kotlin/strikt/gradle/test-logger.gradle.kts
+++ b/buildLogic/src/main/kotlin/strikt/gradle/test-logger.gradle.kts
@@ -1,0 +1,12 @@
+package strikt.gradle
+
+import com.adarshr.gradle.testlogger.theme.ThemeType
+
+plugins {
+  id("com.adarshr.test-logger")
+}
+
+testlogger {
+  theme = ThemeType.MOCHA_PARALLEL
+  showSimpleNames = true
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,8 +79,14 @@ jakarta-servlet-api = { module = "jakarta.servlet:jakarta.servlet-api" }
 # Gradle plugin artifacts (for buildLogic classpath)
 # https://github.com/Kotlin/dokka
 plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+# https://github.com/JetBrains/kotlin
+plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+# https://github.com/jeremymailen/kotlinter-gradle
+plugin-kotlinter = { module = "org.jmailen.kotlinter:org.jmailen.kotlinter.gradle.plugin", version.ref = "kotlinter" }
 # https://github.com/nebula-plugins/nebula-publishing-plugin
 plugin-nebula-publishing = { module = "com.netflix.nebula:nebula-publishing-plugin", version.ref = "nebula" }
+# https://github.com/radarsh/gradle-test-logger-plugin
+plugin-test-logger = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "test-logger" }
 
 [plugins]
 # https://github.com/Kotlin/dokka

--- a/strikt-arrow/strikt-arrow.gradle.kts
+++ b/strikt-arrow/strikt-arrow.gradle.kts
@@ -3,7 +3,7 @@ import java.net.URI
 import java.net.URL
 
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
 }
 

--- a/strikt-core/strikt-core.gradle.kts
+++ b/strikt-core/strikt-core.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
 }
 

--- a/strikt-gradle/strikt-gradle.gradle.kts
+++ b/strikt-gradle/strikt-gradle.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.util.GradleVersion
 import java.net.URL
 
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
 }
 

--- a/strikt-jackson/strikt-jackson.gradle.kts
+++ b/strikt-jackson/strikt-jackson.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import java.net.URI
 
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
 }
 

--- a/strikt-jvm/strikt-jvm.gradle.kts
+++ b/strikt-jvm/strikt-jvm.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
 }
 

--- a/strikt-mockk/strikt-mockk.gradle.kts
+++ b/strikt-mockk/strikt-mockk.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
 }
 

--- a/strikt-protobuf/strikt-protobuf.gradle.kts
+++ b/strikt-protobuf/strikt-protobuf.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import java.net.URI
 
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
   alias(libs.plugins.protobuf)
 }

--- a/strikt-spring/strikt-spring.gradle.kts
+++ b/strikt-spring/strikt-spring.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import java.net.URI
 
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
   alias(libs.plugins.kotlin.spring)
 }


### PR DESCRIPTION
Convert the `subprojects` configuration to convention plugins.

Currently, all the modules are JVM-only Kotlin modules, but that will change soon. With KMP, there will need to be more module-specific configuration that would be difficult to manage externally.

Also, migrate to the `plugins` block, which allows us to use typesafe plugin accessors.