### PR TITLE
Replace failgood test suites with minutest

### DIFF
--- a/buildLogic/src/main/kotlin/strikt/gradle/commonTest.kt
+++ b/buildLogic/src/main/kotlin/strikt/gradle/commonTest.kt
@@ -8,7 +8,7 @@ fun Project.commonTest() {
   tasks.withType<Test> {
     systemProperty("junit.jupiter.execution.parallel.enabled", "false")
     useJUnitPlatform {
-      includeEngines("junit-jupiter", "failgood")
+      includeEngines("junit-jupiter")
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,6 @@
 [versions]
 # https://github.com/arrow-kt/arrow/releases
 arrow = "1.2.4"
-# https://github.com/failgood/failgood/releases
-failgood = "0.9.1"
 # https://central.sonatype.com/artifact/com.fasterxml.jackson/jackson-bom
 jackson = "2.17.2"
 # https://github.com/junit-team/junit5/releases
@@ -41,8 +39,6 @@ versions = "0.51.0"
 [libraries]
 # https://arrow-kt.io/
 arrow = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
-# https://github.com/failgood/failgood
-failgood = { module = "dev.failgood:failgood", version.ref = "failgood" }
 # https://github.com/FasterXML/jackson-bom
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }

--- a/strikt-core/src/jvmTest/kotlin/strikt/assertions/PlatformTypes.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/assertions/PlatformTypes.kt
@@ -1,16 +1,14 @@
 package strikt.assertions
 
-import failgood.Test
-import failgood.describe
-import failgood.testsAbout
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
 import strikt.api.expectThat
 import strikt.java.PersonJava
 
-@Test
-class PlatformTypes {
-  val context =
-    testsAbout("platform types") {
-      describe("when nullability is uncertain") {
+internal object PlatformTypes : JUnit5Minutests {
+  fun tests() =
+    rootContext {
+      context("when nullability is uncertain") {
         val expectation =
           expectThat(PersonJava("Oswald Launcelot Campbell-Graves"))
             .get(PersonJava::getName)

--- a/strikt-core/src/jvmTest/kotlin/strikt/assertions/TupleAssertionsTest.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/assertions/TupleAssertionsTest.kt
@@ -1,15 +1,13 @@
 package strikt.assertions
 
-import failgood.Test
-import failgood.describe
-import failgood.testsAbout
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
 import strikt.api.expectThat
 
-@Test
-class TupleAssertionsTest {
-  val context =
-    testsAbout("tuples") {
-      describe("on an expectation on a pair") {
+internal object TupleAssertionsTest : JUnit5Minutests {
+  fun tests() =
+    rootContext {
+      context("on an expectation on a pair") {
         val expectation = expectThat("a" to 1)
         test("first maps to component1") {
           expectation.first.isEqualTo("a")
@@ -18,16 +16,16 @@ class TupleAssertionsTest {
           expectation.second.isEqualTo(1)
         }
       }
-      describe("on an expectation on a triple") {
-        val pair = Triple("a", "b", 1)
-        val expectation = expectThat(pair)
+      context("on an expectation on a triple") {
+        val triple = Triple("a", "b", 1)
+        val expectation = expectThat(triple)
         test("first maps to component1") {
           expectation.first.isEqualTo("a")
         }
         test("second maps to component2") {
           expectation.second.isEqualTo("b")
         }
-        test("third maps to component2") {
+        test("third maps to component3") {
           expectation.third.isEqualTo(1)
         }
       }

--- a/strikt-core/strikt-core.gradle.kts
+++ b/strikt-core/strikt-core.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
       api(libs.opentest4j)
     }
     jvmTest.dependencies {
-      implementation(libs.failgood)
       implementation(libs.minutest)
     }
   }


### PR DESCRIPTION
After updating failgood version:

```
1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':strikt-arrow:test' (registered by plugin 'org.gradle.jvm-test-suite').
> Test process encountered an unexpected problem.
   > Could not complete execution for Gradle Test Executor 5.
      > No TestEngine ID matched the following include EngineFilters: [failgood].

        Please fix/remove the filter or add the engine.
        Registered TestEngines:
        - minutest (version: DEVELOPMENT, location: jar:file:/home/runner/.gradle/caches/modules-2/files-2.1/dev.minutest/minutest/1.13.0/bb6dd19bbae66236586c17b45272845e5939b61c/minutest-1.13.0.jar!/dev/minutest/junit/engine/MinutestTestEngine.class)
        - junit-jupiter (group ID: org.junit.jupiter, artifact ID: junit-jupiter-engine, version: 5.14.4, location: jar:file:/home/runner/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-engine/5.14.4/dd198558041b67d6a86f801908020ee21cdadf3e/junit-jupiter-engine-5.14.4.jar!/org/junit/jupiter/engine/JupiterTestEngine.class)
        Registered EngineFilters:
        - EngineFilter that includes engines with IDs [junit-jupiter, failgood]
```

Just remove it instead.