### PR TITLE
Fix dokka failing after version 2.x.x update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Generate API docs
-        run: ./gradlew dokkaHtmlMultiModule
+        run: ./gradlew dokkaGenerate
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Generate API docs
-        run: ./gradlew dokkaHtmlMultiModule
+        run: ./gradlew dokkaGenerate
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,10 @@ allprojects {
   }
 }
 
-tasks.dokkaHtmlMultiModule {
-  outputDirectory.set(rootDir.resolve("docs/api"))
+dokka {
+  dokkaPublications.html {
+    outputDirectory.set(rootDir.resolve("docs/api"))
+  }
 }
 
 configure<NexusStagingExtension> {
@@ -46,4 +48,15 @@ tasks.withType<DependencyUpdatesTask> {
   rejectVersionIf {
     candidate.isNonStable()
   }
+}
+
+dependencies {
+  dokka(project(":strikt-bom"))
+  dokka(project(":strikt-core"))
+  dokka(project(":strikt-arrow"))
+  dokka(project(":strikt-jackson"))
+  dokka(project(":strikt-jvm"))
+  dokka(project(":strikt-mockk"))
+  dokka(project(":strikt-protobuf"))
+  dokka(project(":strikt-spring"))
 }

--- a/buildLogic/src/main/kotlin/published.gradle.kts
+++ b/buildLogic/src/main/kotlin/published.gradle.kts
@@ -64,11 +64,9 @@ plugins.withId("kotlin") {
     enabled = false
   }
 
-  tasks.withType<DokkaTaskPartial>().configureEach {
-    dokkaSourceSets {
-      configureEach {
-        jdkVersion.set(11)
-      }
+  dokka {
+    dokkaSourceSets.configureEach {
+      jdkVersion.set(11)
     }
   }
 
@@ -76,7 +74,7 @@ plugins.withId("kotlin") {
     group = "build"
     description = "Assembles Javadoc jar from Dokka API docs"
     archiveClassifier.set("javadoc")
-    from(tasks.dokkaHtml)
+    from(tasks.dokkaGenerate)
   }
 
   publishing {

--- a/strikt-arrow/strikt-arrow.gradle.kts
+++ b/strikt-arrow/strikt-arrow.gradle.kts
@@ -1,7 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import java.net.URI
-import java.net.URL
-
 plugins {
   id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
@@ -18,15 +14,10 @@ dependencies {
   testImplementation(libs.minutest)
 }
 
-tasks.withType<DokkaTaskPartial>().configureEach {
-  dokkaSourceSets {
-    configureEach {
-      "https://arrow-kt.io/docs/apidocs/arrow-core/".also {
-        externalDocumentationLink {
-          url.set(URI(it).toURL())
-          packageListUrl.set(URI("${it}package-list").toURL())
-        }
-      }
+dokka {
+  dokkaSourceSets.configureEach {
+    externalDocumentationLinks.register("arrow-docs") {
+      url("https://apidocs.arrow-kt.io/")
     }
   }
 }

--- a/strikt-jackson/strikt-jackson.gradle.kts
+++ b/strikt-jackson/strikt-jackson.gradle.kts
@@ -1,6 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import java.net.URI
-
 plugins {
   id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
@@ -19,15 +16,10 @@ dependencies {
   testImplementation(libs.minutest)
 }
 
-tasks.withType<DokkaTaskPartial>().configureEach {
-  dokkaSourceSets {
-    configureEach {
-    "https://fasterxml.github.io/jackson-databind/javadoc/2.12/".also {
-      externalDocumentationLink {
-        url.set(URI(it).toURL())
-        packageListUrl.set(URI("${it}package-list").toURL())
-      }
-    }
+dokka {
+  dokkaSourceSets.configureEach {
+    externalDocumentationLinks.register("jackson-docs") {
+      url("https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${libs.versions.jackson.get()}/")
     }
   }
 }

--- a/strikt-mockk/strikt-mockk.gradle.kts
+++ b/strikt-mockk/strikt-mockk.gradle.kts
@@ -13,3 +13,11 @@ dependencies {
   testImplementation(libs.minutest)
   testImplementation(libs.mockk)
 }
+
+dokka {
+  dokkaSourceSets.configureEach {
+    externalDocumentationLinks.register("mockk") {
+      url("https://javadoc.io/doc/io.mockk/mockk/")
+    }
+  }
+}

--- a/strikt-protobuf/strikt-protobuf.gradle.kts
+++ b/strikt-protobuf/strikt-protobuf.gradle.kts
@@ -1,8 +1,5 @@
 @file:Suppress("KDocMissingDocumentation")
 
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import java.net.URI
-
 plugins {
   id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
@@ -18,15 +15,10 @@ dependencies {
   testImplementation(libs.protobuf)
 }
 
-tasks.withType<DokkaTaskPartial>().configureEach {
-  dokkaSourceSets {
-    configureEach {
-      "https://developers.google.com/protocol-buffers/docs/reference/java/".also {
-        externalDocumentationLink {
-          url.set(URI(it).toURL())
-          packageListUrl.set(URI("${it}package-list").toURL())
-        }
-      }
+dokka {
+  dokkaSourceSets.configureEach {
+    externalDocumentationLinks.register("protobuf-docs") {
+      url("https://protobuf.dev/reference/java/api-docs/")
     }
   }
 }

--- a/strikt-spring/strikt-spring.gradle.kts
+++ b/strikt-spring/strikt-spring.gradle.kts
@@ -1,6 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import java.net.URI
-
 plugins {
   id("strikt.gradle.kotlin-jvm")
   alias(libs.plugins.published)
@@ -23,15 +20,16 @@ dependencies {
   testImplementation(libs.spring.boot.starter.web)
 }
 
-tasks.withType<DokkaTaskPartial>().configureEach {
-  dokkaSourceSets {
-    configureEach {
-      "https://docs.spring.io/spring-framework/docs/current/javadoc-api/".also {
-        externalDocumentationLink {
-          url.set(URI(it).toURL())
-          packageListUrl.set(URI("${it}package-list").toURL())
-        }
-      }
+dokka {
+  dokkaSourceSets.configureEach {
+    externalDocumentationLinks.register("spring-docs") {
+      // Not all APIs are contained in the kotlin kdoc.
+      // For example, the whole `org.springframework.http` package from
+      // the `spring-web` artifact can be only found in javadoc.
+      url("https://docs.spring.io/spring-framework/docs/current/javadoc-api/")
+      url("https://docs.spring.io/spring-framework/docs/current/kdoc-api/")
+      // Furthermore, Spring javadoc does not publish the package-list.
+      packageListUrl("https://docs.spring.io/spring-framework/docs/current/kdoc-api/package-list")
     }
   }
 }


### PR DESCRIPTION
Links to Spring javadoc do not seem to work since their javadoc does not publish the `/package-list`. Their kdoc links could have worked, since it does publish `/package-list` but no such API is used in our project.

Mockk docs are hosted on 3rd party servers and often times out. I am not certain it works.

Jackson works.

Protobuf works.

Arrow generates links but points at the wrong artifact (`arrow-cache4k/arrow.core/` instaed of `arrow-core/arrow.core/`.