### PR TITLE
Code samples and api

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Type-safe fluent assertions
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_one"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_one"
 ```
 </div>
 </div>
@@ -41,7 +41,7 @@ Flexible assertions about collections
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_two"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_two"
 ```
 </div>
 <div class="homepage-feature-label" markdown>
@@ -49,7 +49,7 @@ Flexible assertions about collections
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_three"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_three"
 ```
 </div>
 <div class="homepage-feature-label" markdown>
@@ -57,7 +57,7 @@ Make grouping assertions
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_four"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_four"
 ```
 </div>
 </div>
@@ -71,7 +71,7 @@ Use lambdas to execute multiple assertions on a subject at once…
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_five"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_five"
 ```
 </div>
 <div class="homepage-feature-label" markdown>
@@ -79,7 +79,7 @@ Use lambdas to execute multiple assertions on a subject at once…
 </div>
 <div class="homepage-feature-code" markdown>
 ```text
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_six"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_six"
 ```
 </div>
 <div class="homepage-feature-label" markdown>
@@ -87,7 +87,7 @@ Use lambdas to execute assertions on multiple subjects at once…
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_seven"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_seven"
 ```
 </div>
 </div>
@@ -101,7 +101,7 @@ Assertion functions can "narrow" the type of the assertion
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_eight"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_eight"
 ```
 </div>
 <div class="homepage-feature-label" markdown>
@@ -109,7 +109,7 @@ Assertions can "map" to properties and method results in a type safe way
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_nine"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_nine"
 ```
 </div>
 </div>
@@ -123,7 +123,7 @@ Custom assertions are extension functions
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_ten"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_ten"
 ```
 </div>
 <div class="homepage-feature-label" markdown>
@@ -131,8 +131,8 @@ Custom mappings are extension properties
 </div>
 <div class="homepage-feature-code" markdown>
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_eleven_a"
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Homepage.kt:homepage_eleven_b"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_eleven_a"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt:homepage_eleven_b"
 ```
 </div>
 </div>

--- a/docs/modules/arrow.md
+++ b/docs/modules/arrow.md
@@ -10,4 +10,4 @@ testImplementation("io.strikt:strikt-arrow:{{ version }}")
 
 ## API Documentation
 
-- [strikt.arrow](/api/strikt-arrow/strikt.arrow/)
+- [strikt.arrow](../../api/strikt-arrow/strikt.arrow/)

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -10,6 +10,6 @@ testImplementation("io.strikt:strikt-core:{{ version }}")
 
 ## API Documentation
 
-- [strikt.api](/api/strikt-core/strikt.api/)
-- [strikt.assertions](/api/strikt-core/strikt.assertions/)
-- [strikt.internal.opentest4j](/api/strikt-core/strikt.internal.opentest4j/)
+- [strikt.api](../../api/strikt-core/strikt.api/)
+- [strikt.assertions](../../api/strikt-core/strikt.assertions/)
+- [strikt.internal.opentest4j](../../api/strikt-core/strikt.internal.opentest4j/)

--- a/docs/modules/jackson.md
+++ b/docs/modules/jackson.md
@@ -10,4 +10,4 @@ testImplementation("io.strikt:strikt-jackson:{{ version }}")
 
 ## API Documentation
 
-- [strikt.jackson](/api/strikt-jackson/strikt.jackson/)
+- [strikt.jackson](../../api/strikt-jackson/strikt.jackson/)

--- a/docs/modules/jvm.md
+++ b/docs/modules/jvm.md
@@ -10,5 +10,5 @@ testImplementation("io.strikt:strikt-jvm:{{ version }}")
 
 ## API Documentation
 
-- [strikt.java](/api/strikt-jvm/strikt.java/)
-- [strikt.java.time](/api/strikt-jvm/strikt.java.time/)
+- [strikt.java](../../api/strikt-jvm/strikt.java/)
+- [strikt.java.time](../../api/strikt-jvm/strikt.java.time/)

--- a/docs/modules/mockk.md
+++ b/docs/modules/mockk.md
@@ -10,4 +10,4 @@ testImplementation("io.strikt:strikt-mockk:{{ version }}")
 
 ## API Documentation
 
-- [strikt.mockk](/api/strikt-mockk/strikt.mockk/)
+- [strikt.mockk](../../api/strikt-mockk/strikt.mockk/)

--- a/docs/modules/protobuf.md
+++ b/docs/modules/protobuf.md
@@ -10,4 +10,4 @@ testImplementation("io.strikt:strikt-protobuf:{{ version }}")
 
 ## API Documentation
 
-- [strikt.protobuf](/api/strikt-protobuf/strikt.protobuf/)
+- [strikt.protobuf](../../api/strikt-protobuf/strikt.protobuf/)

--- a/docs/modules/spring.md
+++ b/docs/modules/spring.md
@@ -10,4 +10,4 @@ testImplementation("io.strikt:strikt-spring:{{ version }}")
 
 ## API Documentation
 
-- [strikt.spring](/api/strikt-spring/strikt.spring/)
+- [strikt.spring](../../api/strikt-spring/strikt.spring/)

--- a/docs/wiki/assertion-styles.md
+++ b/docs/wiki/assertion-styles.md
@@ -12,13 +12,13 @@ That is, the first assertion that fails breaks the chain and further assertions 
 Each assertion in the chain returns an `Assertion.Builder` object that supports further assertions.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:assertion_styles_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:assertion_styles_1"
 ```
 
 Produces the output:
 
 ```text
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:assertion_styles_2"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:assertion_styles_2"
 ```
 
 Notice that the `isUpperCase()` assertion is not applied as the earlier `hasLength(1)` assertion failed.
@@ -32,13 +32,13 @@ Block assertions do _not_ fail fast.
 That is, all assertions in the block are evaluated, and the result of the "compound" assertion will include results for all the assertions made in the block.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:assertion_styles_3"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:assertion_styles_3"
 ```
 
 Produces the output:
 
 ```text
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:assertion_styles_4"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:assertion_styles_4"
 ```
 
 All assertions are applied and since two fail there are two errors logged.
@@ -48,13 +48,13 @@ All assertions are applied and since two fail there are two errors logged.
 Chained assertions inside a block _will_ still fail fast but will not prevent other assertions in the block from being evaluated.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:assertion_styles_5"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:assertion_styles_5"
 ```
 
 Produces the output:
 
 ```text
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:assertion_styles_6"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:assertion_styles_6"
 ```
 
 Note the `isA<Int>` assertion (that would have failed) was not evaluated since it was chained after `lessThan(1)` which failed.
@@ -70,5 +70,5 @@ All assertions inside the `expect` lambda are evaluated.
 The previous examples can be combined into a single `expect` block.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:assertion_styles_7"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:assertion_styles_7"
 ```

--- a/docs/wiki/collection-elements.md
+++ b/docs/wiki/collection-elements.md
@@ -4,13 +4,13 @@ Some assertions on collections include sub-assertions applied to the elements of
 For example, we can assert that _all_ elements conform to a repeated assertion.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:collections_2"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:collections_2"
 ```
 
 This produces the output:
 
 ```text
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:collections_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:collections_1"
 ```
 
 The results are broken down by individual elements in the collection, so it's easy to see which failed.

--- a/docs/wiki/custom-assertions.md
+++ b/docs/wiki/custom-assertions.md
@@ -28,7 +28,7 @@ The standard assertions `isNull`, `isEqualTo`, `isA<T>` and many others are simp
 Let's imagine we're implementing an assertion function for `java.time.LocalDate` that tests if the represented date is a leap day.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_1"
 ```
 
 Breaking this down:
@@ -41,7 +41,7 @@ Breaking this down:
 If this assertion fails it will produce a message like:
 
 ```text
---8<-- "strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_2"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_2"
 ```
 
 ### Note
@@ -59,13 +59,13 @@ In order to do this, Strikt provides an overridden version of `fail()` that acce
 The message string should contain a format placeholder for the value.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_3"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_3"
 ```
 
 Now if the assertion fails there is a little more detail.
 
 ```text
---8<-- "strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_4"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_4"
 ```
 
 In this case that's not terribly helpful but when dealing with properties, method return values, or the like it can save a lot of effort in identifying the precise cause of an error.
@@ -78,7 +78,7 @@ For the simplest assertion functions, instead of using `assert` and calling `pas
 We can re-implement the example above like this:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_5"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_5"
 ```
 
 You should not use this form when you want to provide a meaningful description of the actual value but for simple assertions it's slightly less verbose.
@@ -96,7 +96,7 @@ Composed assertions are useful for things like:
 Imagine we're creating an assertion function that tests fails if any element of a collection is `null`.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_6"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_6"
 ```
 
 Breaking this down:
@@ -111,7 +111,7 @@ The receiver of the block passed to `result` has the properties `allFailed`, `an
 If the assertion failed we'll see something like this:
 
 ```text
---8<-- "strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_7"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt:custom_assertions_7"
 ```
 
 As well as the overall assertion failure message we get a detailed breakdown allowing us to easily find exactly where the problem is.

--- a/docs/wiki/expecting-exceptions.md
+++ b/docs/wiki/expecting-exceptions.md
@@ -4,7 +4,7 @@ To assert that some code does or does not throw an exception use the `expectCatc
 For example:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:catching_exceptions_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:catching_exceptions_1"
 ```
 
 The `expectCatching` function returns `Assertion.Builder<Try<T>>` with the assertion's subject being a wrapper for either the value the lambda returns, or the exception it throws.
@@ -20,7 +20,7 @@ If you just need to test that _any_ exception was thrown you can just use the `i
 For example:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:catching_exceptions_2"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:catching_exceptions_2"
 ```
 
 ## With block assertions
@@ -29,7 +29,7 @@ For example:
 The `catching` function returns a `Assertion.Builder<Try<T>>` mentioned above.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:catching_exceptions_3"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:catching_exceptions_3"
 ```
 
 ### Shorthand form
@@ -38,7 +38,7 @@ You can also use the `expectThrows<E>(A)` function which is simply a shorthand f
 For example:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:expect_throws_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:expect_throws_1"
 ```
 
 ## Asserting success

--- a/docs/wiki/flow-typing.md
+++ b/docs/wiki/flow-typing.md
@@ -22,7 +22,7 @@ Another example is making assertions about a subject's specific runtime type, or
 For example:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Assertions.kt:flow_typing_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Assertions.kt:flow_typing_1"
 ```
 
 The return type of the subject map's `get()` method is `Any` but using the narrowing assertion `isA<T>()` we can both assert the type of the value and, because the compiler now knows it is dealing with an `Assertion.Builder<String>` or an `Assertion.Builder<Number>`, we can use more specialized assertion methods that are only available for those subject types.

--- a/docs/wiki/grouping-with-and.md
+++ b/docs/wiki/grouping-with-and.md
@@ -14,7 +14,7 @@ The `and` method is helpful in these scenarios.
 For example:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:grouping_with_and_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:grouping_with_and_1"
 ```
 
 The type after `expectThat` is `Assertion.Builder<T?>` (assuming `subject` has a nullable declared type) but the receiver of `and` is `Assertion.Builder<T>` as `isNotNull` has narrowed the subject type.
@@ -25,26 +25,26 @@ Another use for `and` is to create a branch of assertions that apply to a sub-tr
 For example, if testing a complex value type with nested properties:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:grouping_with_and_2"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:grouping_with_and_2"
 ```
 
 The `with` function gives you another option for doing this:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:grouping_with_with_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:grouping_with_with_1"
 ```
 
 Of course, it may be better to structure the same assertion with separate assertions.
 This is a lot more readable:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:grouping_with_and_3"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:grouping_with_and_3"
 ```
 
 Testing properties of a collection can be done similarly:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:grouping_with_and_4"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:grouping_with_and_4"
 ```
 
 ## _with*_ extension functions
@@ -65,5 +65,5 @@ These include:
 For example, the previous assertions could also be written as:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:grouping_with_with_2"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:grouping_with_with_2"
 ```

--- a/docs/wiki/traversing-subjects.md
+++ b/docs/wiki/traversing-subjects.md
@@ -3,7 +3,7 @@
 Although you can obviously write assertions for the properties of an object with code like this:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:traversing_subjects_1"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:traversing_subjects_1"
 ```
 
 Sometimes it's useful to be able to transform an assertion on a subject to an assertion on a property of that subject, or the result of a method call.
@@ -19,7 +19,7 @@ The `get` method returns an `Assertion.Builder<R>` where the new subject (whose 
 This is useful for making assertions about the properties of an object, or the values returned by methods, particularly if you want to use a block-style assertion to validate multiple object properties.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:traversing_subjects_4"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:traversing_subjects_4"
 ```
 
 ## Using _get_ with lambdas
@@ -27,14 +27,14 @@ This is useful for making assertions about the properties of an object, or the v
 An alternate version of the `get` method takes a lambda whose receiver is the current subject.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:traversing_subjects_2"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:traversing_subjects_2"
 ```
 
 Strikt will attempt to read the test source to find out the name of the variables.
 This example produces output that looks like this:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:traversing_subjects_3"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:traversing_subjects_3"
 ```
 
 ### Performance considerations
@@ -54,7 +54,7 @@ If the assertion subject is an `Iterable` Strikt provides a `map` function much 
 It is effectively like using `get` on each element of the `Iterable` subject.
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:traversing_subjects_5"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:traversing_subjects_5"
 ```
 
 In this case the `map` function is transforming the `Assertion.Builder<List<Person>>` into an `Assertion.Builder<List<String>>` by applying the `name` property to each element.
@@ -66,13 +66,13 @@ If you find yourself frequently using `get` for the same properties or methods, 
 For example:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:traversing_subjects_6"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:traversing_subjects_6"
 ```
 
 You can then write the earlier example as:
 
 ```kotlin
---8<-- "strikt-core/src/test/kotlin/strikt/docs/Chaining.kt:traversing_subjects_7"
+--8<-- "strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt:traversing_subjects_7"
 ```
 
 ## Built-in traversals


### PR DESCRIPTION
The migration to KMP changed the path of the tests.

Not sure if the links to api pages worked at all before.