### PR TITLE
Remove java.time from :strikt-core

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ kotlin = "2.3.21"
 kotlinter = "5.5.0"
 # https://github.com/Kotlin/kotlinx.coroutines/releases
 kotlinx-coroutines = "1.11.0"
+# https://github.com/Kotlin/kotlinx-datetime/releases
+kotlinx-datetime = "0.8.0"
 # https://github.com/Kotlin/kotlinx-kover/releases
 kover = "0.9.8"
 # https://central.sonatype.com/artifact/dev.minutest/minutest
@@ -53,6 +55,8 @@ kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin
 # https://github.com/Kotlin/kotlinx.coroutines
 kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
+# https://github.com/Kotlin/kotlinx-datetime
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 # https://github.com/dmcg/minutest
 minutest = { module = "dev.minutest:minutest", version.ref = "minutest" }
 # https://mockk.io/

--- a/strikt-core/src/jvmTest/kotlin/strikt/Block.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/Block.kt
@@ -1,5 +1,6 @@
 package strikt
 
+import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -19,7 +20,6 @@ import strikt.assertions.isNull
 import strikt.assertions.single
 import strikt.assertions.startsWith
 import strikt.internal.opentest4j.IncompleteAssertion
-import java.time.LocalDate
 
 @DisplayName("assertions in blocks")
 internal class Block {
@@ -174,7 +174,7 @@ internal class Block {
   @Test
   fun `can evaluate a block of assertions on a derived subject`() {
     assertThrows<AssertionError> {
-      val subject = Person("David", LocalDate.of(1947, 1, 8))
+      val subject = Person("David", LocalDate(1947, 1, 8))
       expectThat(subject)
         .with("name", Person::name) {
           startsWith("Z")
@@ -199,7 +199,7 @@ internal class Block {
   @Test
   fun `can evaluate a block of assertions with a contextual description on a derived subject`() {
     assertThrows<AssertionError> {
-      val subject = Person("David", LocalDate.of(1947, 1, 8))
+      val subject = Person("David", LocalDate(1947, 1, 8))
       expectThat(subject)
         .with(Person::name) {
           startsWith("Z")
@@ -224,10 +224,10 @@ internal class Block {
   @Test
   fun `can chain after a successful block of assertions on a derived subject`() {
     assertThrows<AssertionError> {
-      val subject = Person("David", LocalDate.of(1947, 1, 8))
+      val subject = Person("David", LocalDate(1947, 1, 8))
       expectThat(subject)
         .with(Person::birthDate) {
-          isLessThan(LocalDate.of(2019, 11, 30))
+          isLessThan(LocalDate(2019, 11, 30))
         }
         .with(Person::name) {
           startsWith("Z")
@@ -254,7 +254,7 @@ internal class Block {
   @Test
   fun `chain after a failing block of assertions on a derived subject is not evaluated`() {
     assertThrows<AssertionError> {
-      val subject = Person("David", LocalDate.of(1947, 1, 8))
+      val subject = Person("David", LocalDate(1947, 1, 8))
       expectThat(subject)
         .with(Person::name) {
           startsWith("Z")
@@ -262,7 +262,7 @@ internal class Block {
           hasLength(5)
         }
         .with(Person::birthDate) {
-          isLessThan(LocalDate.of(2019, 11, 30))
+          isLessThan(LocalDate(2019, 11, 30))
         }
     }.let { error ->
       val expected =

--- a/strikt-core/src/jvmTest/kotlin/strikt/CustomMapping.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/CustomMapping.kt
@@ -1,15 +1,17 @@
 package strikt
 
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
-import java.time.LocalDate
 
 @DisplayName("custom mappings")
 class CustomMapping {
-  val subject = Person("David", LocalDate.of(1947, 1, 8))
+  val subject = Person("David", LocalDate(1947, 1, 8))
 
   @Test
   fun `can map with a closure`() {
@@ -23,7 +25,7 @@ class CustomMapping {
   fun `can map with property and method references`() {
     expectThat(subject) {
       get(Person::name).isEqualTo("David")
-      get(Person::birthDate).get(LocalDate::getYear).isEqualTo(1947)
+      get(Person::birthDate).get(LocalDate::year).isEqualTo(1947)
     }
   }
 
@@ -31,8 +33,8 @@ class CustomMapping {
   fun `closures can call methods`() {
     expectThat(subject) {
       get { name.uppercase() }.isEqualTo("DAVID")
-      get { birthDate.plusYears(69).plusDays(2) }
-        .isEqualTo(LocalDate.of(2016, 1, 10))
+      get { birthDate + DatePeriod(years = 69, days = 2) }
+        .isEqualTo(LocalDate(2016, 1, 10))
     }
   }
 
@@ -101,13 +103,13 @@ class CustomMapping {
     val error =
       assertThrows<AssertionError> {
         expectThat(subject).get(Person::birthDate)
-          .get(LocalDate::getYear)
+          .get(LocalDate::year)
           .isEqualTo(1971)
       }
     expectThat(error.message).isEqualTo(
       """▼ Expect that Person(name=David, birthDate=1947-01-08):
         |  ▼ value of property birthDate:
-        |    ▼ return value of getYear:
+        |    ▼ value of property year:
         |      ✗ is equal to 1971
         |              found 1947
       """.trimMargin()

--- a/strikt-core/src/jvmTest/kotlin/strikt/Mapping.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/Mapping.kt
@@ -1,5 +1,6 @@
 package strikt
 
+import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -20,7 +21,6 @@ import strikt.assertions.last
 import strikt.assertions.map
 import strikt.assertions.message
 import strikt.assertions.single
-import java.time.LocalDate
 
 @DisplayName("mapping assertions")
 internal class Mapping {
@@ -166,6 +166,6 @@ internal class Mapping {
   }
 }
 
-data class Person(val name: String, val birthDate: LocalDate = LocalDate.now())
+data class Person(val name: String, val birthDate: LocalDate = LocalDate(2026, 12, 31))
 
 data class Album(val name: String)

--- a/strikt-core/src/jvmTest/kotlin/strikt/assertions/AnyAssertions.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/assertions/AnyAssertions.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.assertThrows
 import org.opentest4j.AssertionFailedError
 import strikt.api.Assertion.Builder
 import strikt.api.expectThat
-import java.time.Instant
+import kotlin.time.Instant
 
 internal object AnyAssertions : JUnit5Minutests {
   fun tests() =
@@ -231,7 +231,7 @@ internal object AnyAssertions : JUnit5Minutests {
           null to listOf("fnord"),
           listOf("fnord") to null,
           1 to 1L,
-          Instant.now().let { it to Instant.ofEpochMilli(it.toEpochMilli()) }
+          Instant.parse("2026-12-31T12:30:00Z").let { it to Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
         )
           .forEach { (subject, expected) ->
             context("the subject and expected values are different instances") {
@@ -245,7 +245,7 @@ internal object AnyAssertions : JUnit5Minutests {
             }
           }
 
-        listOf("fnord", 1L, null, listOf("fnord"), Instant.now())
+        listOf("fnord", 1L, null, listOf("fnord"), Instant.parse("2026-12-31T12:30:00Z"))
           .map { it to it }
           .forEach { (subject, expected) ->
             context("the subject and expected values are the same instance") {
@@ -264,7 +264,7 @@ internal object AnyAssertions : JUnit5Minutests {
           null to listOf("fnord"),
           listOf("fnord") to null,
           1 to 1L,
-          Instant.now().let { it to Instant.ofEpochMilli(it.toEpochMilli()) }
+          Instant.parse("2026-12-31T12:30:00Z").let { it to Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
         )
           .forEach { (subject, expected) ->
             context("the subject and expected values are different instances") {
@@ -276,7 +276,7 @@ internal object AnyAssertions : JUnit5Minutests {
             }
           }
 
-        listOf("fnord", 1L, null, listOf("fnord"), Instant.ofEpochMilli(0))
+        listOf("fnord", 1L, null, listOf("fnord"), Instant.fromEpochMilliseconds(0))
           .map { it to it }
           .forEach { (subject, expected) ->
             context("the subject and expected values are the same instance") {

--- a/strikt-core/src/jvmTest/kotlin/strikt/assertions/ComparableAssertions.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/assertions/ComparableAssertions.kt
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.assertThrows
 import strikt.api.Assertion
 import strikt.api.expectThat
-import java.time.Instant
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
 
 @DisplayName("assertions on Comparable")
 internal object ComparableAssertions {
@@ -117,9 +118,9 @@ internal object ComparableAssertions {
     assertionTests<Instant> {
       context("an Instant subject") {
         supportsComparisonAssertions(
-          Instant.now(),
-          { minusMillis(1) },
-          { plusMillis(1) }
+          Instant.parse("2026-12-31T12:30:00Z"),
+          { minus(1.milliseconds) },
+          { plus(1.milliseconds) }
         )
       }
     }

--- a/strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/docs/Chaining.kt
@@ -1,5 +1,6 @@
 package strikt.docs
 
+import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -21,7 +22,6 @@ import strikt.assertions.withFirst
 import strikt.assertions.withLast
 import strikt.internal.opentest4j.CompoundAssertionFailure
 import strikt.internal.opentest4j.IncompleteAssertion
-import java.time.LocalDate
 
 @DisplayName("Snippets used in Orchid docs")
 internal class Chaining {
@@ -59,7 +59,7 @@ internal class Chaining {
 
     expectThrows<CompoundAssertionFailure> {
       // --8<-- [start:traversing_subjects_2]
-      val subject = Person(name = "David", birthDate = LocalDate.of(1947, 1, 8))
+      val subject = Person(name = "David", birthDate = LocalDate(1947, 1, 8))
       expectThat(subject) {
         get { name }.isEqualTo("Ziggy")
         get { birthDate.year }.isEqualTo(1971)
@@ -72,10 +72,10 @@ internal class Chaining {
 
   @Test fun `traversing subjects 4`() {
     // --8<-- [start:traversing_subjects_4]
-    val subject = Person(name = "David", birthDate = LocalDate.of(1947, 1, 8))
+    val subject = Person(name = "David", birthDate = LocalDate(1947, 1, 8))
     expectThat(subject) {
       get(Person::name).isEqualTo("David")
-      get(Person::birthDate).get(LocalDate::getYear).isEqualTo(1947)
+      get(Person::birthDate).get(LocalDate::year).isEqualTo(1947)
     }
     // --8<-- [end:traversing_subjects_4]
   }
@@ -108,7 +108,7 @@ internal class Chaining {
 
   @Test fun `traversing subjects 7`() {
     // --8<-- [start:traversing_subjects_7]
-    val subject = Person(name = "David", birthDate = LocalDate.of(1947, 1, 8))
+    val subject = Person(name = "David", birthDate = LocalDate(1947, 1, 8))
     expectThat(subject) {
       name.isEqualTo("David")
       yearOfBirth.isEqualTo(1947)
@@ -134,7 +134,7 @@ internal class Chaining {
   }
 
   @Test fun `grouping with and 2, 3`() {
-    val person = Person(name = "David", birthDate = LocalDate.of(1947, 1, 8))
+    val person = Person(name = "David", birthDate = LocalDate(1947, 1, 8))
     // --8<-- [start:grouping_with_and_2]
     expectThat(person)
       .and {

--- a/strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/docs/CustomAssertions.kt
@@ -1,5 +1,7 @@
 package strikt.docs
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.opentest4j.AssertionFailedError
@@ -9,8 +11,6 @@ import strikt.api.expectThrows
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.message
-import java.time.LocalDate
-import java.time.MonthDay
 
 @DisplayName("Snippets used in Orchid docs")
 internal class CustomAssertions {
@@ -21,10 +21,8 @@ internal class CustomAssertions {
     // --8<-- [start:custom_assertions_1]
     fun Assertion.Builder<LocalDate>.isStTibsDay(): Assertion.Builder<LocalDate> =
       assert("is St. Tib's Day") {
-        when (MonthDay.from(it)) {
-          MonthDay.of(2, 29) -> pass()
-          else -> fail()
-        }
+        if (it.month == Month.FEBRUARY && it.day == 29) pass()
+        else fail()
       }
     // --8<-- [end:custom_assertions_1]
 
@@ -37,7 +35,7 @@ internal class CustomAssertions {
       """
 
     expectThrows<AssertionFailedError> {
-      expectThat(LocalDate.of(2018, 5, 1)).isStTibsDay()
+      expectThat(LocalDate(2018, 5, 1)).isStTibsDay()
     }
       .message
       .isEqualTo(s.removeSnippetTags().trimIndent().trim())
@@ -47,14 +45,11 @@ internal class CustomAssertions {
     // --8<-- [start:custom_assertions_3]
     fun Assertion.Builder<LocalDate>.isStTibsDay(): Assertion.Builder<LocalDate> =
       assert("is St. Tib's Day") {
-        when (MonthDay.from(it)) {
-          MonthDay.of(2, 29) -> pass()
-          else ->
-            fail(
-              description = "in fact it is %s",
-              actual = it
-            )
-        }
+        if (it.month == Month.FEBRUARY && it.day == 29) pass()
+        else fail(
+          description = "in fact it is %s",
+          actual = it
+        )
       }
     // --8<-- [end:custom_assertions_3]
 
@@ -68,7 +63,7 @@ internal class CustomAssertions {
       """
 
     expectThrows<AssertionFailedError> {
-      expectThat(LocalDate.of(2018, 5, 1)).isStTibsDay()
+      expectThat(LocalDate(2018, 5, 1)).isStTibsDay()
     }
       .message
       .isEqualTo(s.removeSnippetTags().trimIndent().trim())
@@ -78,7 +73,7 @@ internal class CustomAssertions {
     // --8<-- [start:custom_assertions_5]
     fun Assertion.Builder<LocalDate>.isStTibsDay(): Assertion.Builder<LocalDate> =
       assertThat("is St. Tib's Day") {
-        MonthDay.from(it) == MonthDay.of(2, 29)
+        it.month == Month.FEBRUARY && it.day == 29
       }
     // --8<-- [end:custom_assertions_5]
 
@@ -89,7 +84,7 @@ internal class CustomAssertions {
       """
 
     expectThrows<AssertionFailedError> {
-      expectThat(LocalDate.of(2018, 5, 1)).isStTibsDay()
+      expectThat(LocalDate(2018, 5, 1)).isStTibsDay()
     }
       .message
       .isEqualTo(s.trimIndent().trim())

--- a/strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt
+++ b/strikt-core/src/jvmTest/kotlin/strikt/docs/Homepage.kt
@@ -1,5 +1,7 @@
 package strikt.docs
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import strikt.Person
@@ -21,8 +23,6 @@ import strikt.assertions.matches
 import strikt.assertions.message
 import strikt.assertions.startsWith
 import strikt.internal.opentest4j.CompoundAssertionFailure
-import java.time.LocalDate
-import java.time.MonthDay
 
 // Wrap each code snippet in comments like "// --8<-- [start:name] ... // --8<-- [end:name]"
 // Code snippets can be referenced from the docs using pymdownx.snippets
@@ -134,12 +134,10 @@ internal class Homepage {
     // --8<-- [start:homepage_ten]
     fun Assertion.Builder<LocalDate>.isStTibsDay() =
       assert("is St. Tib's Day") {
-        when (MonthDay.from(it)) {
-          MonthDay.of(2, 29) -> pass()
-          else -> fail()
-        }
+        if (it.month == Month.FEBRUARY && it.day == 29) pass()
+        else fail()
       }
-    expectThat(LocalDate.of(2020, 2, 29)).isStTibsDay()
+    expectThat(LocalDate(2020, 2, 29)).isStTibsDay()
     // --8<-- [end:homepage_ten]
   }
 

--- a/strikt-core/strikt-core.gradle.kts
+++ b/strikt-core/strikt-core.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
     }
     jvmTest.dependencies {
       implementation(libs.minutest)
+      implementation(libs.kotlinx.datetime)
     }
   }
 }


### PR DESCRIPTION
Replace the `java.time` with `kotlinx.datetime` and `kotlin.time.Instant` in `:strikt-core` `jvmTest` source set. The `jvmMain` source set did not use any `java.time` APIs.

`java.time` will not be accessible once the `:strikt-core` module targets any other platforms other than Java.

The `:strikt-jvm` module's `strikt.java.time` package is left untouched.